### PR TITLE
track develop branch instead of feature branch.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
   }
   stages {
     stage('Build-Test-Package') {
-      when { changeRequest target: anyof {'master', 'release', 'feature'} }
+      when { changeRequest target: anyof {'master', 'develop', 'release'} }
       matrix {
       agent { label "agent-${PLATFORM}" }
         when { anyof {


### PR DESCRIPTION
feature branches are temporary and jenkins build is not required as they are not the integration points.